### PR TITLE
README.rst: Use reST for Travis CI badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -41,7 +41,8 @@ Running::
 
     $ python -m unittest tests
 
-[![Build Status](https://travis-ci.org/toastdriven/pylev.png)](https://travis-ci.org/toastdriven/pylev)
+.. image:: https://secure.travis-ci.org/toastdriven/pylev.png
+   :target: http://travis-ci.org/toastdriven/pylev
 
 
 Version History


### PR DESCRIPTION
markdown in a README.rst doesn't work

Preview at https://github.com/msabramo/pylev/blob/patch-2/README.rst