### PR TITLE
Update README - assert is not a function

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -22,7 +22,7 @@ Usage is fairly straightforward:
 
     import pylev
     distance = pylev.levenshtein('kitten', 'sitting')
-    assert(distance, 3)
+    assert distance == 3
 
 
 License


### PR DESCRIPTION
`assert(distance, 3)` means `assert (distance, 3)`, where the tuple `(distance, 3)` is trivially truthy as all tuples of length 1+ are truthy.