### PR TITLE
fix: close file after opening

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,10 @@
-import os
-
 try:
     from setuptools import setup
 except ImportError:
     from distutils.core import setup
 
+with open("README.rst", "r") as f:
+    long_description = f.read()
 
 setup(
     name="pylev",
@@ -12,9 +12,7 @@ setup(
     description="A pure Python Levenshtein implementation that's not freaking GPL'd.",
     author="Daniel Lindsley",
     author_email="daniel@toastdriven.com",
-    long_description=open(
-        os.path.join(os.path.dirname(__file__), "README.rst"), "r"
-    ).read(),
+    long_description=long_description,
     packages=["pylev"],
     include_package_data=True,
     zip_safe=False,


### PR DESCRIPTION
You must always close a file after opening it. The current code might not work on Windows + PyPy, since it's assuming the garbage collector will run (which it won't on PyPy) & the file descriptor will be released (which is required on Windows).